### PR TITLE
Walk into packages

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,0 +1,80 @@
+var environment = require('./environment');
+var Walker = require('walker')
+  , fs = require('fs')
+  , path = require('path')
+  , makeError = require('makeerror');
+
+var PackageNotFoundError = exports.PackageNotFoundError = makeError(
+  'PackageNotFoundError',
+  "ENOTFOUND - Package {package} not found"
+)
+
+function walk(directory) {
+  var noSubDirs = [];
+
+  return Walker(directory)
+    .filterDir(function(dir, stat) {
+      //exclude any subdir to an excluded dir
+      return !noSubDirs.some(function(subdir) {
+        return !subdir.indexOf(dir); //true if starts with dir
+      }) || !stopped;// stops also if end has been emitted
+    })
+    .on('file', function(file, stat) {
+      var shortname = path.basename(file);
+      var dir = path.dirname(file);
+
+      if( shortname === 'manifest.xml')
+        this.emit('package', path.basename(dir), dir)
+      else if(shortname === 'rospack_nosubdirs')
+        noSubDirs.concat(dir);
+    })
+    .on('symlink', function(symlink, stat) {
+
+    })
+    .on('end', function(){
+      stopped = true;
+      this.emit = function(){}; //if stopped then we should not emit anything else
+    })
+}
+
+function findPackageInDirectory(directory, package, callback) {
+  var found = false;
+  walk(directory).on('package', function(name, dir) {
+    if(name === package) {
+      this.emit('stop'); // will stop any further processing
+      found = true;
+      callback(null, dir);
+    }
+  }).on('end', function() {
+    if(!found) {
+      callback(PackageNotFoundError({package:package}))
+    }
+  })
+}
+
+function findPackageInDirectoryChain(directories, package, callback) {
+  if(directories.length<1) {
+    return callback(PackageNotFoundError({package:package}));
+  }
+  return findPackageInDirectory(directories.shift(), package, function onRosRootPackageSearch(err, directory) {
+    if(err instanceof PackageNotFoundError) {
+
+      //not found in this directory, then chain in the next one
+      directory = environment.getRosRoot();
+      //recursive call
+      return findPackageInDirectoryChain(directories, package, callback)
+    } else if(err) {
+      //unknown error
+      return callback(err);
+    } else {
+      //ok we found it
+      return callback(null, directory);
+    }
+  });
+}
+
+//implements the same crawling algorithm as rospack find : http://ros.org/doc/api/rospkg/html/rospack.html
+exports.findPackage = function findPackage(package, callback) {
+  var directories = [environment.getRosRoot()].concat(environment.getRosPackagePaths());
+  return findPackageInDirectoryChain(directories, package, callback);
+}

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -7,10 +7,13 @@ var Walker = require('walker')
 var PackageNotFoundError = exports.PackageNotFoundError = makeError(
   'PackageNotFoundError',
   "ENOTFOUND - Package {package} not found"
-)
+);
 
-function walk(directory) {
+var packageCache = [];
+
+function walk(directory, symlinks) {
   var noSubDirs = [];
+  symlinks = symlinks || [];
 
   return Walker(directory)
     .filterDir(function(dir, stat) {
@@ -24,12 +27,37 @@ function walk(directory) {
       var dir = path.dirname(file);
 
       if( shortname === 'manifest.xml')
-        this.emit('package', path.basename(dir), dir)
+        this.emit('package', path.basename(dir), dir);
       else if(shortname === 'rospack_nosubdirs')
         noSubDirs.concat(dir);
     })
     .on('symlink', function(symlink, stat) {
+      var walker = this;
+      fs.readlink(symlink, function(err, link){
+        if(err) {
+          return; //ignore and stop this branch
+        }
 
+        var destination = path.resolve(path.dirname(symlink), link);
+
+        //stores symlinks to avoid circular references
+        if(~symlinks.indexOf(destination)){
+          //already passed here, just ignore it
+          return;
+        } else { //not stored yet ? add it
+          symlinks.concat(destination);
+        }
+
+        fs.stat(destination, function(err, stat){
+          if(err) {
+            return;
+          }
+          if(stat.isDirectory()) {//ok, then follow symlink !
+            walker.emit('dir', destination, stat);
+            return walker.go(destination);
+          }
+        })
+      })
     })
     .on('end', function(){
       stopped = true;
@@ -39,7 +67,9 @@ function walk(directory) {
 
 function findPackageInDirectory(directory, package, callback) {
   var found = false;
-  walk(directory).on('package', function(name, dir) {
+  return walk(directory).on('package', function(name, dir) {
+    //first, adds the package to the cache
+
     if(name === package) {
       this.emit('stop'); // will stop any further processing
       found = true;
@@ -47,7 +77,7 @@ function findPackageInDirectory(directory, package, callback) {
     }
   }).on('end', function() {
     if(!found) {
-      callback(PackageNotFoundError({package:package}))
+      callback(PackageNotFoundError({package:package}));
     }
   })
 }
@@ -58,11 +88,8 @@ function findPackageInDirectoryChain(directories, package, callback) {
   }
   return findPackageInDirectory(directories.shift(), package, function onRosRootPackageSearch(err, directory) {
     if(err instanceof PackageNotFoundError) {
-
-      //not found in this directory, then chain in the next one
-      directory = environment.getRosRoot();
-      //recursive call
-      return findPackageInDirectoryChain(directories, package, callback)
+      //recursive call, try in next directory
+      return findPackageInDirectoryChain(directories, package, callback);
     } else if(err) {
       //unknown error
       return callback(err);

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -26,10 +26,14 @@ function walk(directory, symlinks) {
       var shortname = path.basename(file);
       var dir = path.dirname(file);
 
-      if( shortname === 'manifest.xml')
+      if( shortname === 'manifest.xml') {
         this.emit('package', path.basename(dir), dir);
-      else if(shortname === 'rospack_nosubdirs')
+        //there is no subpackages, so ignore anything under this directory
         noSubDirs.concat(dir);
+      } else if(shortname === 'rospack_nosubdirs') {
+        //explicitely asked to not go into subdirectories, so don't
+        noSubDirs.concat(dir);
+      }
     })
     .on('symlink', function(symlink, stat) {
       var walker = this;

--- a/package.json
+++ b/package.json
@@ -1,37 +1,48 @@
-{ "name" : "rosnodejs"
-, "description" : "A JavaScript client library for ROS."
-, "keywords" : [ "ros", "rosnode", "rosnodejs", "robot", "robotics" ]
-, "version" : "0.0.2"
-, "preferGlobal" : false
-, "homepage" : "https://github.com/baalexander/rosnodejs"
-, "author" : "Brandon Alexander <baalexander@gmail.com> (https://github.com/baalexander)"
-, "repository" : {
-    "type" : "git"
-  , "url"  : "git://github.com/baalexander/rosnodejs.git"
-  }
-, "bugs" : {
-    "url" : "https://github.com/baalexander/rosnodejs/issues"
-  }
-, "directories" : {
-    "lib" : "./lib"
-  }
-, "main" : "./lib/rosnode.js"
-, "dependencies" : {
-    "portscanner" : "0.1.2"
-  , "xmlrpc"      : "0.9.3"
-  , "backbone"    : "0.9.x"
-  }
-, "devDependencies" : {
-    "mocha"  : "0.10.x"
-  , "should" : "0.5.x"
-  , "rimraf" : "2.0.x"
-  }
-, "engines" : {
-    "node" : ">=0.6", "npm" : ">=1.0.0"
-  }
-, "licenses" : [ {
-    "type" : "MIT"
-  , "url" : "https://github.com/baalexander/rosnodejs/raw/master/LICENSE"
-  } ]
+{
+  "name": "rosnodejs",
+  "description": "A JavaScript client library for ROS.",
+  "keywords": [
+    "ros",
+    "rosnode",
+    "rosnodejs",
+    "robot",
+    "robotics"
+  ],
+  "version": "0.0.2",
+  "preferGlobal": false,
+  "homepage": "https://github.com/baalexander/rosnodejs",
+  "author": "Brandon Alexander <baalexander@gmail.com> (https://github.com/baalexander)",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/baalexander/rosnodejs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/baalexander/rosnodejs/issues"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "./lib/rosnode.js",
+  "dependencies": {
+    "portscanner": "0.1.2",
+    "xmlrpc": "0.9.3",
+    "backbone": "0.9.x",
+    "walker": "~1.0.3",
+    "makeerror": "~1.0.8"
+  },
+  "devDependencies": {
+    "mocha": "0.10.x",
+    "should": "0.5.x",
+    "rimraf": "2.0.x"
+  },
+  "engines": {
+    "node": ">=0.6",
+    "npm": ">=1.0.0"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/baalexander/rosnodejs/raw/master/LICENSE"
+    }
+  ]
 }
-


### PR DESCRIPTION
Adds a helper to walk into packages, which will be more than useful to retrieve message definitions to avoid message generation.

FYI, on my laptop, here is some performance information :

``` js
var packages = require('./lib/packages');

//time to reach one package in my ROS_WORKSPACE
console.time('pack');
packages.findPackage('turtlenode', function() {console.timeEnd('pack')})
//logs "pack: 37ms" 

//time to reach the tutorial stack package 'turtlesim'
console.time('pack');
packages.findPackage('turtlesim', function() {console.timeEnd('pack')})
// logs "pack: 107ms"
```

Walking algorithm may use parallelization rather than chain, but it will be pretty much more difficult to find which entry has the precedence (and to stop when the good one is retrieve) in the path if multiple package matches, and hard drives are pretty poor at parallel search (... but this is not true for flash or ssd, which may be used in robots), so it can globally slows the search if we have only one package matching the name.

We can also add some cache pretty easily (like rospack does, we can even share the cache with it), but it's not done yet.

Please note that it does not follow symlinks for now.

Please note it's not that well tested against 'rospackage_nosubdirs'  file, but it should take it in account
