### PR TITLE
fix navbar's href id from 'about_ros' to 'about-ros'

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <a class="brand" href="#overview">rosnodejs</a>
       <ul class="nav">
         <li>
-          <a href="#about_ros">
+          <a href="#about-ros">
             <img class="nav-icon" src="images/robot-light-small.png"/>
             About ROS
           </a>


### PR DESCRIPTION
Hi, i found a very very small bug in your rosnodejs homepage.

very small patch for it.
