### PR TITLE
supporting catkin packages

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -22,7 +22,7 @@ function walk(directory, symlinks) {
       var shortname = path.basename(file);
       var dir = path.dirname(file);
 
-      if (shortname === 'manifest.xml') {
+      if (shortname === 'manifest.xml' || shortname === 'package.xml') {
         this.emit('package', path.basename(dir), dir);
         // There is no subpackages, so ignore anything under this directory
         noSubDirs.concat(dir);


### PR DESCRIPTION
Now rosnodejs does not support catkin packages (catkin is a new package manager introduced from groovy).

Catkin packages have package.xml like manifest.xml, so we need to check package.xml as well as manifest.xml.

test code:

``` javascript
var packages = require("./lib/packages");
packages.findPackage("roscpp", function(err, pack) { console.log(err); console.log(pack);});
```

`````` sh
echo $ROS_DISTRO
> groovy
ls `rospack find roscpp`
> cmake  msg  package.xml  rosbuild  srv```
``````
